### PR TITLE
added "Portal" to title filter for terminal articles

### DIFF
--- a/generate_terminals.py
+++ b/generate_terminals.py
@@ -33,7 +33,7 @@ def scroll_history():
 def remove_specials(title):
     return not (
         title.split(":")[0]
-        in ("Special", "Help", "Wikipedia", "File", "User", "Template", "Category")
+        in ("Special", "Help", "Wikipedia", "File", "User", "Template", "Category", "Portal")
         or title in ("Main_Page", "404.php")
         or "disambiguation" in title.lower()
     )

--- a/terminal_articles.txt
+++ b/terminal_articles.txt
@@ -2,7 +2,6 @@ United States Senate
 XHamster
 Donald Trump
 Elizabeth II
-Portal:Current events
 United States
 Darth Vader
 Elon Musk
@@ -296,7 +295,6 @@ List of Canadian stand-up comedians
 List of British stand-up comedians
 Ben Affleck
 Salman Khan
-Portal:Contents
 Tom Holland (actor)
 Netflix
 Frank Sinatra
@@ -13413,7 +13411,6 @@ Fear Factor: Khatron Ke Khiladi 10
 Niecy Nash
 The Dead Don't Die (2019 film)
 Mustafa Kemal Atatürk
-Portal:Featured content
 2018 FIVB Volleyball Men's Nations League
 Celestial (comics)
 Luzhniki Stadium


### PR DESCRIPTION
Missed this when I made the terminal article script the first time.